### PR TITLE
Feature/homeat 28

### DIFF
--- a/HOMEAT/Presentation/HomeScene/Components/TagButton.swift
+++ b/HOMEAT/Presentation/HomeScene/Components/TagButton.swift
@@ -49,7 +49,7 @@ extension TagButton {
     private func setConstraints() {
         self.snp.makeConstraints {
             $0.height.equalTo(40)
-            $0.width.equalTo(94)
+//            $0.width.equalTo(94)
         }
     }
     

--- a/HOMEAT/Presentation/HomeScene/Components/TagButton.swift
+++ b/HOMEAT/Presentation/HomeScene/Components/TagButton.swift
@@ -49,7 +49,6 @@ extension TagButton {
     private func setConstraints() {
         self.snp.makeConstraints {
             $0.height.equalTo(40)
-//            $0.width.equalTo(94)
         }
     }
     

--- a/HOMEAT/Presentation/HomeScene/Controller/PayAddViewController.swift
+++ b/HOMEAT/Presentation/HomeScene/Controller/PayAddViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import Then
 
-class PayAddViewController : BaseViewController {
+class PayAddViewController: BaseViewController {
     
     //MARK: - Property
     private let cameraButton = UIButton()
@@ -23,6 +23,7 @@ class PayAddViewController : BaseViewController {
     private let cameraActionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
     
     private let tagStackView = UIStackView()
+    private let imagePicker = UIImagePickerController()
     
     //MARK: - Function
     override func viewDidLoad() {
@@ -88,7 +89,7 @@ class PayAddViewController : BaseViewController {
         }
         
         tagStackView.do {
-            $0.spacing = 20
+            $0.spacing = 18
             $0.axis = .horizontal
             $0.alignment = .fill
             $0.distribution = .fillEqually
@@ -121,7 +122,9 @@ class PayAddViewController : BaseViewController {
         }
         
         cameraActionSheet.do {
-            let takeAction = UIAlertAction(title: "사진 촬영", style: .default, handler: nil)
+            let takeAction = UIAlertAction(title: "사진 촬영", style: .default) { [self] action in
+                present(imagePicker, animated: true, completion: nil)
+            }
             let selectAction = UIAlertAction(title: "앨범에서 사진 선택", style: .default, handler: nil)
             let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
             takeAction.setValue(UIColor.white, forKey: "titleTextColor")
@@ -130,6 +133,13 @@ class PayAddViewController : BaseViewController {
             $0.addAction(takeAction)
             $0.addAction(selectAction)
             $0.addAction(cancelAction)
+        }
+        
+        imagePicker.do {
+            $0.sourceType = .camera
+            $0.allowsEditing = true
+            $0.cameraDevice = .rear
+            $0.delegate = self
         }
     }
     
@@ -201,5 +211,17 @@ class PayAddViewController : BaseViewController {
     
     @objc func cameraButtonTapped(_ sender: Any) {
         present(cameraActionSheet, animated: true)
+    }
+}
+
+extension PayAddViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        picker.dismiss(animated: true)
+        
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
     }
 }

--- a/HOMEAT/Presentation/HomeScene/Controller/PayAddViewController.swift
+++ b/HOMEAT/Presentation/HomeScene/Controller/PayAddViewController.swift
@@ -122,8 +122,8 @@ class PayAddViewController: BaseViewController {
         }
         
         cameraActionSheet.do {
-            let takeAction = UIAlertAction(title: "사진 촬영", style: .default) { [self] action in
-                present(imagePicker, animated: true, completion: nil)
+            let takeAction = UIAlertAction(title: "사진 촬영", style: .default) { action in
+                self.present(self.imagePicker, animated: true, completion: nil)
             }
             let selectAction = UIAlertAction(title: "앨범에서 사진 선택", style: .default, handler: nil)
             let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
@@ -217,6 +217,9 @@ class PayAddViewController: BaseViewController {
 extension PayAddViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[UIImagePickerController.InfoKey(rawValue: "UIImagePickerControllerEditedImage")] as? UIImage {
+            cameraButton.setImage(image, for: .normal)
+        }
         picker.dismiss(animated: true)
         
     }

--- a/HOMEAT/Presentation/HomeScene/View/PayCheckView.swift
+++ b/HOMEAT/Presentation/HomeScene/View/PayCheckView.swift
@@ -163,11 +163,6 @@ class PayCheckView: BaseView {
         }
         
         homefoodSpentLabel.snp.makeConstraints {
-            $0.centerY.equalTo(homefoodTitleLabel)
-            $0.trailing.equalToSuperview()
-        }
-        
-        homefoodSpentLabel.snp.makeConstraints {
             $0.centerY.equalTo(homefoodTitleLabel).offset(-4)
             $0.trailing.equalToSuperview()
         }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
- 지출 추가 부분의 사진 촬영과 라이브러리에서 사진을 가져오는 기능을 추가했습니다
- 사진을 가져 온 뒤 뷰의 촬영 버튼과 대치되도록 만들었습니다

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
다음과 같은 오류로그가 발생했지만 해결방안을 찾지 못했습니다
- 카메라 촬영 버튼을 클릭 할 시에 기능은 정상 작동 되지만 다음과 같은 오류로그가 발생함

<img width="532" alt="image" src="https://github.com/Homeat/HOMEAT_iOS/assets/145318322/533c13e6-01e5-4529-8a94-afb1e4bf29e6">

- 시뮬레이터와 휴대폰이 연결 돼 있을 때 지출 추가 화면으로 전환 시에 몇초간의 앱 멈춤 이후 전환됨. 다음과 같은 오류로그 발생, 하지만 시뮬레이터 연결 해제 이후에는 멈춤 없이 잘 작동됨

<img width="532" alt="image" src="https://github.com/Homeat/HOMEAT_iOS/assets/145318322/8c7918a7-a8d6-483f-bcaa-5108299fc023">


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- 없습니다. 추후 사용 시에 info파일 정도 수정해야 할 것 같습니다


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


## ❇️ 스크린샷이 있다면 첨부해주세요

![image](https://github.com/Homeat/HOMEAT_iOS/assets/145318322/3c2496a4-587c-4a59-b812-1bdc0ff53b07)

### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #50 
