### PR TITLE
[HOMEAT-36] Feat [#60] 이메일 로그인 통신 구현

### DIFF
--- a/HOMEAT.xcodeproj/project.pbxproj
+++ b/HOMEAT.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		011DAFDA2BE3ABC4000556D0 /* EatoutCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DAFD92BE3ABC4000556D0 /* EatoutCheckView.swift */; };
 		011DAFDD2BE3AC6D000556D0 /* CalendarCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DAFDC2BE3AC6D000556D0 /* CalendarCollectionViewCell.swift */; };
 		011DAFDF2BE3ACA7000556D0 /* PayCheckDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DAFDE2BE3ACA7000556D0 /* PayCheckDetailViewController.swift */; };
+		011DAFE12BEB6C3A000556D0 /* EmailLoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DAFE02BEB6C3A000556D0 /* EmailLoginResponseDTO.swift */; };
+		011DAFE32BEB6C67000556D0 /* EmailLoginRequestBodyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DAFE22BEB6C67000556D0 /* EmailLoginRequestBodyDTO.swift */; };
 		012382E52BB3F96D0048CC2D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012382E42BB3F96D0048CC2D /* AppDelegate.swift */; };
 		012382E72BB3F96D0048CC2D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012382E62BB3F96D0048CC2D /* SceneDelegate.swift */; };
 		012382E92BB3F96D0048CC2D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 012382E82BB3F96D0048CC2D /* HomeViewController.swift */; };
@@ -117,6 +119,8 @@
 		011DAFD92BE3ABC4000556D0 /* EatoutCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EatoutCheckView.swift; sourceTree = "<group>"; };
 		011DAFDC2BE3AC6D000556D0 /* CalendarCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionViewCell.swift; sourceTree = "<group>"; };
 		011DAFDE2BE3ACA7000556D0 /* PayCheckDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayCheckDetailViewController.swift; sourceTree = "<group>"; };
+		011DAFE02BEB6C3A000556D0 /* EmailLoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailLoginResponseDTO.swift; sourceTree = "<group>"; };
+		011DAFE22BEB6C67000556D0 /* EmailLoginRequestBodyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailLoginRequestBodyDTO.swift; sourceTree = "<group>"; };
 		012382E12BB3F96D0048CC2D /* HOMEAT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HOMEAT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		012382E42BB3F96D0048CC2D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		012382E62BB3F96D0048CC2D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -588,6 +592,7 @@
 			isa = PBXGroup;
 			children = (
 				01D531302BDFC5E1008C368E /* KakaoLoginRequestBodyDTO.swift */,
+				011DAFE22BEB6C67000556D0 /* EmailLoginRequestBodyDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -598,6 +603,7 @@
 				01D531322BDFC647008C368E /* KakaoLoginResponseDTO.swift */,
 				01D5313A2BDFCCBB008C368E /* UserInfoResponseDTO.swift */,
 				01D531422BDFCE6A008C368E /* TokenRefreshResponseDTO.swift */,
+				011DAFE02BEB6C3A000556D0 /* EmailLoginResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -755,6 +761,7 @@
 			files = (
 				011DAFDD2BE3AC6D000556D0 /* CalendarCollectionViewCell.swift in Sources */,
 				01D531022BD14D89008C368E /* LoginViewController.swift in Sources */,
+				011DAFE32BEB6C67000556D0 /* EmailLoginRequestBodyDTO.swift in Sources */,
 				01D530F62BC7E9AC008C368E /* APIEventLogger.swift in Sources */,
 				01D531432BDFCE6A008C368E /* TokenRefreshResponseDTO.swift in Sources */,
 				012383B42BBD75D30048CC2D /* UserInfoTableViewCell.swift in Sources */,
@@ -770,6 +777,7 @@
 				01D530F02BC7C4F9008C368E /* NetworkResult.swift in Sources */,
 				012382E92BB3F96D0048CC2D /* HomeViewController.swift in Sources */,
 				011DAFD42BE3AB96000556D0 /* CalendarView.swift in Sources */,
+				011DAFE12BEB6C3A000556D0 /* EmailLoginResponseDTO.swift in Sources */,
 				012383B22BBD32100048CC2D /* UserInfoViewController.swift in Sources */,
 				58FE4CDA2BC801BA0059D174 /* WeekCollectionViewCell.swift in Sources */,
 				0123833F2BB7ECCD0048CC2D /* StringLiterals.swift in Sources */,

--- a/HOMEAT.xcodeproj/project.pbxproj
+++ b/HOMEAT.xcodeproj/project.pbxproj
@@ -377,18 +377,10 @@
 		012383382BB7E95B0048CC2D /* OnboardingScene */ = {
 			isa = PBXGroup;
 			children = (
-				012383392BB7EA9F0048CC2D /* Model */,
 				01D530FE2BCFDFBA008C368E /* View */,
 				01D530F92BCFB79F008C368E /* Controller */,
 			);
 			path = OnboardingScene;
-			sourceTree = "<group>";
-		};
-		012383392BB7EA9F0048CC2D /* Model */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Model;
 			sourceTree = "<group>";
 		};
 		012383402BB7F8E90048CC2D /* Global */ = {

--- a/HOMEAT/Network/Base/BaseResponse.swift
+++ b/HOMEAT/Network/Base/BaseResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct BaseResponse<T: Decodable>: Decodable {
-    let code: Int
+    let code: String
     let message: String
     let isSuccess: Bool
     let data: T?

--- a/HOMEAT/Network/Base/BaseResponse.swift
+++ b/HOMEAT/Network/Base/BaseResponse.swift
@@ -10,5 +10,6 @@ import Foundation
 struct BaseResponse<T: Decodable>: Decodable {
     let code: Int
     let message: String
+    let isSuccess: Bool
     let data: T?
 }

--- a/HOMEAT/Network/Base/HOMEATRequestInterceptor.swift
+++ b/HOMEAT/Network/Base/HOMEATRequestInterceptor.swift
@@ -55,7 +55,7 @@ final class HOMEATRequestInterceptor: RequestInterceptor {
             guard let self else {return}
             switch result {
             case .success(let data):
-                if data.code == 200 {
+                if data.code == "COMMON_200" {
                     /// 토큰 재발급에 성공하여 다시 저장.
                     guard let data = data.data else { return }
                     print("리프레쉬 토큰을 사용하여 토큰을 재발행하여 저장했습니다. ✅")
@@ -63,7 +63,7 @@ final class HOMEATRequestInterceptor: RequestInterceptor {
                     KeychainHandler.shared.accessToken = data.accessToken
                     completion(true)
                     return
-                } else if data.code == 404 {
+                } else if data.code == "AUTH_4010" {
                     print("이미 탈퇴한 사용자로 찾을 수 없습니다.❌")
 //                    self.logout()
                 }

--- a/HOMEAT/Network/Base/HTTPHeaderField.swift
+++ b/HOMEAT/Network/Base/HTTPHeaderField.swift
@@ -35,4 +35,5 @@ enum Authorization {
     case unauthorization
     case socialAuthorization
     case reAuthorization
+    case emailAuthorization
 }

--- a/HOMEAT/Network/Base/TargetType.swift
+++ b/HOMEAT/Network/Base/TargetType.swift
@@ -65,6 +65,8 @@ extension TargetType {
             urlRequest.setValue(KeychainHandler.shared.providerToken, forHTTPHeaderField: HTTPHeaderField.providerToken.rawValue)
         case .reAuthorization:
             urlRequest.setValue(KeychainHandler.shared.refreshToken, forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
+        case .emailAuthorization:
+            urlRequest.setValue("Bearer \(KeychainHandler.shared.accessToken)", forHTTPHeaderField: HTTPHeaderField.authentication.rawValue)
         }
         
         switch headerType {

--- a/HOMEAT/Network/Onboarding/DTO/Request/EmailLoginRequestBodyDTO.swift
+++ b/HOMEAT/Network/Onboarding/DTO/Request/EmailLoginRequestBodyDTO.swift
@@ -1,0 +1,13 @@
+//
+//  EmailLoginRequestBodyDTO.swift
+//  HOMEAT
+//
+//  Created by 강석호 on 5/8/24.
+//
+
+import Foundation
+
+struct EmailLoginRequestBodyDTO: Codable {
+    let email: String
+    let password: String
+}

--- a/HOMEAT/Network/Onboarding/DTO/Response/EmailLoginResponseDTO.swift
+++ b/HOMEAT/Network/Onboarding/DTO/Response/EmailLoginResponseDTO.swift
@@ -1,0 +1,14 @@
+//
+//  EmailLoginResponseDTO.swift
+//  HOMEAT
+//
+//  Created by 강석호 on 5/8/24.
+//
+
+import Foundation
+
+struct EmailLoginResponseDTO: Codable {
+    let isSuccess: Bool
+    let code: String
+    let message: String
+}

--- a/HOMEAT/Network/Onboarding/Router/OnboardingTarget.swift
+++ b/HOMEAT/Network/Onboarding/Router/OnboardingTarget.swift
@@ -10,7 +10,8 @@ import Alamofire
 
 
 enum OnboardingTarget {
-    case login(_ bodyDTO: KakaoLoginRequestBodyDTO)
+    case kakaoLogin(_ bodyDTO: KakaoLoginRequestBodyDTO)
+    case emailLogin(_ bodyDTO: EmailLoginRequestBodyDTO)
     case userInfo
     case postRefreshToken
 }
@@ -19,56 +20,66 @@ extension OnboardingTarget: TargetType {
     
     var authorization: Authorization {
         switch self {
-        case .login:
+        case .kakaoLogin:
             return .socialAuthorization
         case .userInfo:
             return .authorization
         case .postRefreshToken:
             return .reAuthorization
+        case .emailLogin:
+            return .emailAuthorization
         }
     }
     
     var headerType: HTTPHeaderType {
         switch self {
-        case .login:
+        case .kakaoLogin:
             return .providerToken
         case .userInfo:
             return .hasToken
         case .postRefreshToken:
             return .refreshToken
+        case .emailLogin:
+            return .plain
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .login:
+        case .kakaoLogin:
             return .post
         case .userInfo:
             return .get
         case .postRefreshToken:
+            return .post
+        case .emailLogin:
             return .post
         }
     }
     
     var path: String {
         switch self {
-        case .login:
+        case .kakaoLogin:
             return "/v1/auth/login"
         case .userInfo:
             return "/v1/users/me"
         case .postRefreshToken:
             return "/v1/auth/reissue"
+        case .emailLogin:
+            return "/v1/members/login"
         }
     }
     
     var parameters: RequestParams {
         switch self {
-        case let .login(bodyDTO):
+        case let .kakaoLogin(bodyDTO):
             return .requestWithBody(bodyDTO)
         case .userInfo:
             return .requestPlain
         case .postRefreshToken:
             return .requestPlain
+        case let .emailLogin(bodyDTO):
+            return .requestWithBody(bodyDTO)
         }
     }
     

--- a/HOMEAT/Network/Onboarding/Service/OnboardingService.swift
+++ b/HOMEAT/Network/Onboarding/Service/OnboardingService.swift
@@ -31,7 +31,11 @@ final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingSer
     }
     
     func emailLogin(bodyDTO: EmailLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<EmailLoginResponseDTO>>) -> Void) {
-        fetchData(target: .emailLogin(bodyDTO),
-                  responseData: BaseResponse<EmailLoginResponseDTO>.self, completion: completion)
+        fetchDataWithHeader(target: .emailLogin(bodyDTO),
+                            responseData: BaseResponse<EmailLoginResponseDTO>.self, completion: { (result, headers) in
+            // 여기에서 필요한 작업을 수행하고 최종 결과를 `completion`으로 넘깁니다.
+            completion(result)
+            print(headers)
+        })
     }
 }

--- a/HOMEAT/Network/Onboarding/Service/OnboardingService.swift
+++ b/HOMEAT/Network/Onboarding/Service/OnboardingService.swift
@@ -8,15 +8,16 @@
 import Foundation
 
 protocol OnboardingServiceProtocol {
-    func login(bodyDTO: KakaoLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<KakaoLoginResponseDTO>>) -> Void)
+    func kakaoLogin(bodyDTO: KakaoLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<KakaoLoginResponseDTO>>) -> Void)
     func userInfo(completion: @escaping (NetworkResult<BaseResponse<UserInfoResponseDTO>>) -> Void)
     func postRefreshToken(completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>) -> Void)
+    func emailLogin(bodyDTO: EmailLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<EmailLoginResponseDTO>>) -> Void)
 }
 
 final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingServiceProtocol {
     
-    func login(bodyDTO: KakaoLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<KakaoLoginResponseDTO>>) -> Void) {
-        fetchData(target: .login(bodyDTO),
+    func kakaoLogin(bodyDTO: KakaoLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<KakaoLoginResponseDTO>>) -> Void) {
+        fetchData(target: .kakaoLogin(bodyDTO),
                   responseData: BaseResponse<KakaoLoginResponseDTO>.self, completion: completion)
     }
     
@@ -27,5 +28,10 @@ final class OnboardingService: APIRequestLoader<OnboardingTarget>, OnboardingSer
     
     func postRefreshToken(completion: @escaping (NetworkResult<BaseResponse<TokenRefreshResponseDTO>>) -> Void) {
         fetchData(target: .postRefreshToken, responseData: BaseResponse<TokenRefreshResponseDTO>.self, completion: completion)
+    }
+    
+    func emailLogin(bodyDTO: EmailLoginRequestBodyDTO, completion: @escaping (NetworkResult<BaseResponse<EmailLoginResponseDTO>>) -> Void) {
+        fetchData(target: .emailLogin(bodyDTO),
+                  responseData: BaseResponse<EmailLoginResponseDTO>.self, completion: completion)
     }
 }

--- a/HOMEAT/Presentation/OnboardingScene/Controller/LoginViewController.swift
+++ b/HOMEAT/Presentation/OnboardingScene/Controller/LoginViewController.swift
@@ -9,9 +9,6 @@ import Foundation
 import UIKit
 import Then
 import SnapKit
-import KakaoSDKUser
-import KakaoSDKAuth
-import KakaoSDKCommon
 
 final class LoginViewController : BaseViewController {
     
@@ -21,7 +18,6 @@ final class LoginViewController : BaseViewController {
     private let passwordLabel = UILabel()
     private let passwordTextField = UITextField()
     private let loginButton = UIButton()
-    private let kakaoButton = UIButton()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,6 +56,7 @@ final class LoginViewController : BaseViewController {
             let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 18, height: $0.frame.height))
             $0.leftView = leftPaddingView
             $0.leftViewMode = .always
+            $0.attributedPlaceholder = NSAttributedString(string: "이메일 입력", attributes: [NSAttributedString.Key.foregroundColor: UIColor(r: 216, g: 216, b: 216)])
         }
         
         passwordLabel.do {
@@ -79,19 +76,22 @@ final class LoginViewController : BaseViewController {
             let leftPaddingView = UIView(frame: CGRect(x: 0, y: 0, width: 18, height: $0.frame.height))
             $0.leftView = leftPaddingView
             $0.leftViewMode = .always
+            $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 입력", attributes: [NSAttributedString.Key.foregroundColor: UIColor(r: 216, g: 216, b: 216)])
         }
         
-        kakaoButton.do {
-            $0.backgroundColor = UIColor(r: 254, g: 229, b: 0)
-            $0.setImage(UIImage(named: "kakaoLogo"), for: .normal)
-            $0.layer.cornerRadius = 27
+        loginButton.do {
+            $0.backgroundColor = UIColor(named: "turquoiseGreen")
+            $0.titleLabel?.font = .bodyMedium18
+            $0.setTitle("로그인", for: .normal)
+            $0.setTitleColor(.black, for: .normal)
+            $0.layer.cornerRadius = 10
             $0.clipsToBounds = true
         }
     }
     
     override func setConstraints() {
         
-        view.addSubviews(homeatTextLogo, emailLabel, emailTextField, passwordLabel, passwordTextField, kakaoButton)
+        view.addSubviews(homeatTextLogo, emailLabel, emailTextField, passwordLabel, passwordTextField, loginButton)
         
         homeatTextLogo.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -122,138 +122,39 @@ final class LoginViewController : BaseViewController {
             $0.height.equalTo(57)
         }
         
-        kakaoButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(passwordTextField.snp.bottom).offset(52)
+        loginButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().offset(-20)
+            $0.top.equalTo(passwordTextField.snp.bottom).offset(72)
             $0.height.equalTo(57)
-            $0.width.equalTo(57)
         }
         
     }
     
     private func setTarget() {
-        kakaoButton.addTarget(self, action: #selector(loginKakao), for: .touchUpInside)
+        loginButton.addTarget(self, action: #selector(loginButtonTapped), for: .touchUpInside)
     }
     
-    @objc private func loginKakao(_ sender: Any) {
-        print("loginKakao() called.")
-        
-        // ✅ 카카오톡 설치 여부 확인
-        if (UserApi.isKakaoTalkLoginAvailable()) {
-            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
-                if let error = error {
-                    print(error)
+    @objc private func loginButtonTapped(_ sender: Any) {
+        self.login(data: EmailLoginRequestBodyDTO(email: "rkdtnlzl@naver.com", password: "abcd1234!"))
+    }
+    
+    func login(data: EmailLoginRequestBodyDTO) {
+        NetworkService.shared.onboardingService.emailLogin(bodyDTO: data) { [weak self] response in
+            guard let self = self else { return }
+            switch response {
+            case .success(let data):
+                guard let data = data.data else { return }
+                print(data)
+                let tabBarVC = HOMEATTabBarController()
+                if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                    sceneDelegate.changeRootViewController(to: tabBarVC)
                 }
-                else {
-                    print("loginWithKakaoTalk() success.")
-                    
-                    // ✅ 회원가입 성공 시 oauthToken 저장가능하다
-                    // _ = oauthToken
-                    print("*************")
-                    print(oauthToken!)
-                    print("*************")
-                    // ✅ 사용자정보를 성공적으로 가져오면 화면전환 한다.
-//                    self.getUserInfo()
-                    print("-----------------")
-//                    self.isToken()
-                }
+                print("로그인 성공!!")
+            default:
+                print("login error!!")
             }
-        }
-        else {
-            print("카카오톡 미설치")
         }
     }
 }
 
-extension LoginViewController {
-    
-    private func getUserInfo() {
-        
-        // ✅ 사용자 정보 가져오기
-        UserApi.shared.me() {(user, error) in
-            if let error = error {
-                print(error)
-            }
-            else {
-                print("me() success.")
-                
-                // ✅ 닉네임, 이메일 정보
-                let nickname = user?.kakaoAccount?.profile?.nickname
-                
-                print(nickname!)
-                
-            }
-        }
-    }
-    
-    private func getAccessTokenInfo() {
-        
-        UserApi.shared.accessTokenInfo {(accessTokenInfo, error) in
-            if let error = error {
-                print(error)
-            }
-            else {
-                print("accessTokenInfo() success.")
-                
-                //do something
-                _ = accessTokenInfo
-                print(accessTokenInfo!)
-            }
-        }
-    }
-    
-    private func isToken() {
-        if (AuthApi.hasToken()) {
-            UserApi.shared.accessTokenInfo { (_, error) in
-                if let error = error {
-                    if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true  {
-                        //로그인 필요
-                        print("로그인 필요")
-                    }
-                    else {
-                        //기타 에러
-                        print("기타 에러")
-                    }
-                }
-                else {
-                    //토큰 유효성 체크 성공(필요 시 토큰 갱신됨)
-                    print("토큰 유효성 체크 성공")
-                }
-            }
-        }
-        else {
-            //로그인 필요
-            print("로그인 필요!")
-        }
-    }
-    
-    // MARK: 서버에 카카오톡 토큰 전달
-    /*
-    private func pushTokenFromKakaoLogin(_ info: TokenInfo, completion: @escaping (String?, String?, String?, Error?)->()) {
-        var request = URLRequest(url: URL(string: self.urlCollections["pushKakaoToken"]!)!)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONEncoder().encode(info)
-        URLSession.shared.dataTask(with: request) { data, response, error in
-            if let error = error {
-                print(error.localizedDescription)
-                completion(nil, nil, nil, error)
-            } else if let data = data {
-                let jsonData = try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
-                // 제이슨 파싱해서 유저정보(닉네임, 이메일 가져오기)
-                if let jsonObjData = jsonData?["data"] as? NSDictionary {
-                    if let jsonKeyDataNickname = jsonObjData["nickname"] as? String,
-                       let jsonKeyDataEmail = jsonObjData["email"] as? String,
-                       let jsonKeyDataProvider = jsonObjData["provider"] as? String {
-                        //print("good good \(jsonKeyDataEmail) \(jsonKeyDataNickname)")
-                        completion(jsonKeyDataEmail, jsonKeyDataNickname, jsonKeyDataProvider, nil)
-                    }
-                }
-                if let response = response {
-                    print("Push Kakao token and returned response is: \(response)")
-                }
-            }
-        }.resume()
-    }
-    */
-}

--- a/HOMEAT/Presentation/OnboardingScene/Controller/OnBoardingViewController.swift
+++ b/HOMEAT/Presentation/OnboardingScene/Controller/OnBoardingViewController.swift
@@ -9,13 +9,17 @@ import Foundation
 import UIKit
 import Then
 import SnapKit
+import KakaoSDKUser
+import KakaoSDKAuth
+import KakaoSDKCommon
 
 class OnBoardingViewController : BaseViewController {
     
     private let introTitleLabel = UILabel()
     private let welcomeView = WelcomeView()
-    private let signupButton = UIButton()
-    private let signinButton = UIButton()
+    private let continueEmailButton = UIButton()
+    private let continueKakaoButton = UIButton()
+    private let continueAppleButton = UIButton()
     
     // MARK: Life Cycle
     override func viewDidLoad() {
@@ -35,19 +39,19 @@ class OnBoardingViewController : BaseViewController {
             $0.textColor = .turquoiseGreen
         }
         
-        signupButton.do {
+        continueEmailButton.do {
             $0.backgroundColor = UIColor(named: "turquoiseGreen")
             $0.titleLabel?.font = .bodyMedium18
-            $0.setTitle("가입하기", for: .normal)
+            $0.setTitle("이메일로 계속하기", for: .normal)
             $0.setTitleColor(.black, for: .normal)
             $0.layer.cornerRadius = 10
             $0.clipsToBounds = true
         }
         
-        signinButton.do {
+        continueKakaoButton.do {
             $0.backgroundColor = UIColor(r: 30, g: 32, b: 33)
             $0.titleLabel?.font = .bodyMedium18
-            $0.setTitle("계정이 이미 있어요", for: .normal)
+            $0.setTitle("카카오로 계속하기", for: .normal)
             $0.setTitleColor(.turquoiseGreen, for: .normal)
             $0.layer.cornerRadius = 10
             $0.clipsToBounds = true
@@ -55,10 +59,20 @@ class OnBoardingViewController : BaseViewController {
             $0.layer.borderWidth = 1
         }
         
+        continueAppleButton.do {
+            $0.backgroundColor = UIColor(r: 30, g: 32, b: 33)
+            $0.titleLabel?.font = .bodyMedium18
+            $0.setTitle("Apple로 계속하기", for: .normal)
+            $0.setTitleColor(.turquoiseGreen, for: .normal)
+            $0.layer.cornerRadius = 10
+            $0.clipsToBounds = true
+            $0.layer.borderColor = UIColor.turquoiseGreen.cgColor
+            $0.layer.borderWidth = 1
+        }
     }
     
     override func setConstraints() {
-        view.addSubviews(introTitleLabel, welcomeView, signupButton, signinButton)
+        view.addSubviews(introTitleLabel, welcomeView, continueEmailButton, continueKakaoButton, continueAppleButton)
         
         introTitleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -71,14 +85,21 @@ class OnBoardingViewController : BaseViewController {
             $0.top.equalTo(introTitleLabel.snp.bottom).offset(15)
         }
         
-        signupButton.snp.makeConstraints {
+        continueEmailButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().offset(-20)
-            $0.bottom.equalTo(signinButton.snp.top).offset(-25)
+            $0.bottom.equalTo(continueKakaoButton.snp.top).offset(-25)
             $0.height.equalTo(57)
         }
         
-        signinButton.snp.makeConstraints {
+        continueKakaoButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+            $0.trailing.equalToSuperview().offset(-20)
+            $0.bottom.equalTo(continueAppleButton.snp.top).offset(-25)
+            $0.height.equalTo(57)
+        }
+        
+        continueAppleButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().offset(-20)
             $0.bottom.equalToSuperview().offset(-76)
@@ -87,21 +108,45 @@ class OnBoardingViewController : BaseViewController {
     }
     
     private func setTarget() {
-        signupButton.addTarget(self, action: #selector(signupButtonTapped), for: .touchUpInside)
-        signinButton.addTarget(self, action: #selector(signinButtonTapped), for: .touchUpInside)
+        continueEmailButton.addTarget(self, action: #selector(emailButtonTapped), for: .touchUpInside)
+        continueKakaoButton.addTarget(self, action: #selector(kakaoButtonTapped), for: .touchUpInside)
+        continueAppleButton.addTarget(self, action: #selector(appleButtonTapped), for: .touchUpInside)
     }
     
     //MARK: - @objc Func
-    @objc private func signupButtonTapped(_ sender: Any) {
+    @objc private func emailButtonTapped(_ sender: Any) {
         let nextVC = LoginViewController()
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
     
-    @objc private func signinButtonTapped() {
+    @objc private func kakaoButtonTapped(_ sender: Any) {
+        print("loginKakao() called.")
+        // ✅ 카카오톡 설치 여부 확인
+        if (UserApi.isKakaoTalkLoginAvailable()) {
+            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                }
+                else {
+                    print("loginWithKakaoTalk() success.")
+                    
+                    // ✅ 회원가입 성공 시 oauthToken 저장가능하다
+                    // _ = oauthToken
+                    print("-------------------------------------")
+                    print(oauthToken!)
+                    print("-------------------------------------")
+                }
+            }
+        }
+        else {
+            print("카카오톡 미설치")
+        }
+    }
+    
+    @objc private func appleButtonTapped() {
         let tabBarVC = HOMEATTabBarController()
         if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
             sceneDelegate.changeRootViewController(to: tabBarVC)
         }
     }
-    
 }


### PR DESCRIPTION
## ❇️ 작업한 내용에 대해 설명해주세요

로컬로그인 통신 구현 했습니다.
다만 현재 로그인 시, 서버에서 토큰을 헤더로 저장해서 전달하도록 설정했습니다. 이에 대해서 해승님이랑 얘기중이고 일단은 이대로 진행하기로 했습니다. ios에서는 body로 전달해야 토큰 받는 방식이 올바르게 될 거라고 생각해서 수정하는 방향으로 말씀드렸습니다.

다음 이슈에 회원가입 UI 작업 진행하겠습니다.

## ❇️ 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- header에 있는 데이터를 받기 위해 fetchDataWithHeader를 추가하였습니다.
- 이메일 로그인에 대한 case도 onboardingTarget에 추가하였습니다.


## ❇️ 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- 


## ❇️ PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [x] UI 디자인 구현 혹은 변경
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] info.plist / package 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ❇️ Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


### ❇️ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #60
